### PR TITLE
Standardize imagecropper module naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Modern Android media toolkit built with Kotlin.
 
 ## Current Modules
 
-### Image Picker
+### imagepicker
 - Gallery image picking
 - Camera image capture
 - Lifecycle-aware handling
 - Error callbacks
 - Crop integration support
 
-### Image Cropper
+### imagecropper
 - Matrix-based crop engine
 - Custom crop overlay
 - Crop rectangle controls
@@ -22,7 +22,7 @@ Modern Android media toolkit built with Kotlin.
 
 ```text
 MediaKit-android/
-├── ImageCropper/
+├── imagecropper/ (mapped from existing ImageCropper directory)
 ├── imagepicker/
 ├── sample-app/
 ├── docs/

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
@@ -20,7 +21,9 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "MediaKit-android"
-//include(":ImageCropper", ":sample-app")
-include(":ImageCropper")
+
+include(":imagecropper")
+project(":imagecropper").projectDir = file("ImageCropper")
+
 include(":sample-app")
 include(":imagepicker")


### PR DESCRIPTION
## Summary

Standardize the ImageCropper module naming to align with the rest of the MediaKit ecosystem.

### Changes
- Updated Gradle module include from `:ImageCropper` to `:imagecropper`
- Mapped existing `ImageCropper` directory to the new module name
- Updated README references

### Goal
Improve naming consistency, publishing readiness, and long-term SDK maintainability.